### PR TITLE
Add Batfish and allinone image dockerfiles, scripts

### DIFF
--- a/README.dev.md
+++ b/README.dev.md
@@ -1,0 +1,17 @@
+# Building and pushing images
+
+A single `build_images.sh` script is provided that:
+- Builds a Batfish docker image
+- Tests it with Pybatfish integration tests,
+- Builds an `allinone` docker image (with Jupyter, Pybatfish, and Batfish), 
+- And finally pushes both of these images to the public Batfish organization on docker hub.  
+
+Specific Batfish and Pybatfish commit hashes can be passed into the script 
+to build from those commits instead of `HEAD` at `master` (the default).  
+For example, the following command will build images from the Batfish commit `3337ec...` and Pybatfish commit `ddcb50...`:
+```
+sh build_images.sh 3337ecf49f9f754d502e8aa5443919bea18afdd6 ddcb50bb8c05cbcfa71c261c146bc1360e581961
+```
+Any image built will be tagged with the corresponding Batfish and Pybatfish commits and the `latest` tag.
+
+**NOTE: If you have the correct permissions to docker hub, the images will be pushed to docker hub.**

--- a/README.dev.md
+++ b/README.dev.md
@@ -4,7 +4,7 @@ A single `build_images.sh` script is provided that:
 - Builds a Batfish docker image,
 - Tests it with Pybatfish integration tests,
 - Builds an `allinone` docker image (with Jupyter, Pybatfish, and Batfish), 
-- And finally pushes both of these images to the public Batfish organization on docker hub.  
+- And finally pushes both of these images to the public Batfish organization on Docker Hub.  
 
 Specific Batfish and Pybatfish commit hashes can be passed into the script 
 to build from those commits instead of `HEAD` at `master` (the default). For example, the following command will build images from the Batfish commit `3337ec...` and Pybatfish commit `ddcb50...`:

--- a/README.dev.md
+++ b/README.dev.md
@@ -1,17 +1,16 @@
 # Building and pushing images
 
 A single `build_images.sh` script is provided that:
-- Builds a Batfish docker image
+- Builds a Batfish docker image,
 - Tests it with Pybatfish integration tests,
 - Builds an `allinone` docker image (with Jupyter, Pybatfish, and Batfish), 
 - And finally pushes both of these images to the public Batfish organization on docker hub.  
 
 Specific Batfish and Pybatfish commit hashes can be passed into the script 
-to build from those commits instead of `HEAD` at `master` (the default).  
-For example, the following command will build images from the Batfish commit `3337ec...` and Pybatfish commit `ddcb50...`:
+to build from those commits instead of `HEAD` at `master` (the default). For example, the following command will build images from the Batfish commit `3337ec...` and Pybatfish commit `ddcb50...`:
 ```
 sh build_images.sh 3337ecf49f9f754d502e8aa5443919bea18afdd6 ddcb50bb8c05cbcfa71c261c146bc1360e581961
 ```
 Any image built will be tagged with the corresponding Batfish and Pybatfish commits and the `latest` tag.
 
-**NOTE: If you have the correct permissions to docker hub, the images will be pushed to docker hub.**
+**NOTE: If you have the correct permissions to Docker Hub, the images will be pushed to Docker Hub.**

--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 # Batfish Docker Images
 
-This repo contains the files necessary to build [Batfish](https://github.com/batfish/batfish) and `allinone` (Batfish plus [Pybatfish](https://github.com/batfish/pybatfish) and Jupyter) docker images.  Using one of the prebuilt containers from [Docker hub](https://hub.docker.com/u/batfish/dashboard/) is the quickest and easiest way to get started using Batfish.
+This repo contains the files necessary to build [Batfish](https://github.com/batfish/batfish) and `allinone` (Batfish plus [Pybatfish](https://github.com/batfish/pybatfish) and Jupyter) docker images.  
+Using one of the prebuilt containers from [Docker hub](https://hub.docker.com/u/batfish/dashboard/) is the quickest and easiest way to get started using Batfish.
 
 
 ## Building and Pushing
 
-The `build_images.sh` script builds a Batfish docker image, tests it with Pybatfish integration tests, builds an `allinone` docker image (with Jupyter, Pybatfish, and Batfish), and finally pushes both of these images to the public Batfish organization on docker hub.  Specific Batfish and Pybatfish commit hashes can be passed into the script to build from those commits instead of head (the default).  For example, the following command will build images from the Batfish commit `3337ec...` and Pybatfish commit `ddcb50...`:
+The `build_images.sh` script builds a Batfish docker image, tests it with Pybatfish integration tests, builds an `allinone` docker image (with Jupyter, Pybatfish, and Batfish), 
+and finally pushes both of these images to the public Batfish organization on docker hub.  
+Specific Batfish and Pybatfish commit hashes can be passed into the script to build from those commits instead of head (the default).  
+For example, the following command will build images from the Batfish commit `3337ec...` and Pybatfish commit `ddcb50...`:
 ```
 sh build_images.sh 3337ecf49f9f754d502e8aa5443919bea18afdd6 ddcb50bb8c05cbcfa71c261c146bc1360e581961
 ```
@@ -31,7 +35,7 @@ Can alternatively run the following to gain access to the Batfish data saves on 
 ```
 mkdir -p networks
 mkdir -p data
-docker run -v $(pwd)/networks:/notebooks/custom_networks:ro -v $(pwd)/data:/data -v /etc/group:/etc/group:ro -v /etc/passwd:/etc/passwd:ro --user=$(id -u) --env HOME="/notebooks" -p 8888:8888 batfish/allinone:latest
+docker run -v $(pwd)/networks:/notebooks/custom_networks:ro -v $(pwd)/data:/data -v /etc/group:/etc/group:ro -v /etc/passwd:/etc/passwd:ro --user=$(id -u):$(id -g) --env HOME="/notebooks" -p 8888:8888 batfish/allinone:latest
 ```
 
 ### Batfish

--- a/README.md
+++ b/README.md
@@ -1,2 +1,41 @@
-# docker
-Docker containers for Batfish and Pybatfish
+# Batfish Docker Images
+
+This repo contains the files necessary to build [Batfish](https://github.com/batfish/batfish) and `allinone` (Batfish plus [Pybatfish](https://github.com/batfish/pybatfish) and Jupyter) docker images.  Using one of the prebuilt containers from [Docker hub](https://hub.docker.com/u/batfish/dashboard/) is the quickest and easiest way to get started using Batfish.
+
+
+## Building and Pushing
+
+The `build_images.sh` script builds a Batfish docker image, tests it with Pybatfish integration tests, builds an `allinone` docker image (with Jupyter, Pybatfish, and Batfish), and finally pushes both of these images to the public Batfish organization on docker hub.  Specific Batfish and Pybatfish commit hashes can be passed into the script to build from those commits instead of head (the default).  For example, the following command will build images from the Batfish commit `3337ec...` and Pybatfish commit `ddcb50...`:
+```
+sh build_images.sh 3337ecf49f9f754d502e8aa5443919bea18afdd6 ddcb50bb8c05cbcfa71c261c146bc1360e581961
+```
+Any image built will be tagged with the corresponding Batfish and Pybatfish commits.
+
+
+## Running Containers
+
+### Allinone
+To run the Batfish + Pybatfish + Jupyter docker image for the first time, run:
+```
+mkdir -p networks
+docker run -v $(pwd)/networks:/notebooks/custom_networks:ro -v /etc/group:/etc/group:ro -v /etc/passwd:/etc/passwd:ro --user=$(id -u) --env HOME="/notebooks" -p 8888:8888 batfish/allinone:latest
+```
+This does several things to enable data to be passed into the container from the host:
+* Creates `networks` directory on the host owned and accessible by the current user
+* Runs Batfish and Jupyter processes in the container as the current user
+* Mounts the host's `networks` dir as read-only for the container (specifically Jupyter) to view its contents
+* Mounts the host's `group` and `passwd` files so the host user can run Batfish and Jupyter inside the container (so any files created are owned and accessible by them on the host as well as in the container)
+* Forwards the container Jupyter port to the host's port 8888, so notebooks can be accessed from the host machine with `http://localhost:8888/`
+
+Can alternatively run the following to gain access to the Batfish data saves on disk (and make that data persistent):
+```
+mkdir -p networks
+mkdir -p data
+docker run -v $(pwd)/networks:/notebooks/custom_networks:ro -v $(pwd)/data:/data -v /etc/group:/etc/group:ro -v /etc/passwd:/etc/passwd:ro --user=$(id -u) --env HOME="/notebooks" -p 8888:8888 batfish/allinone:latest
+```
+
+### Batfish
+To run the docker image just containing Batfish, run:
+```
+docker run -p 9997:9997 -p 9996:9996 batfish/batfish:latest
+```

--- a/README.md
+++ b/README.md
@@ -3,15 +3,14 @@
 This repo contains the source files necessary to build [Batfish](https://github.com/batfish/batfish) and 
 `allinone` (Batfish plus [Pybatfish](https://github.com/batfish/pybatfish) and Jupyter) docker images.  
 
-Using one of the pre-built containers from [Docker hub](https://hub.docker.com/u/batfish/dashboard/) 
+Using one of the pre-built containers from [Docker Hub](https://hub.docker.com/u/batfish/) 
 is the quickest and easiest way to get started using Batfish.
 
-## Running Containers
+## Running containers
 
-* For a getting started experience, follow the [All-in-one guide](allinone.md).
-* For running the Batfish service *only*, follow the [Service guide](batfish.md).
+* For a getting started experience, follow the [allinone guide](allinone.md).
+* For running the Batfish service *only*, follow the [Batfish service guide](batfish.md).
 
-## Building and Pushing images
+## Building and pushing images
 
-If you are a developer of batfish see [dev instructions](README.dev.md) on how to build images
-and push them to docker hub.
+If you are a developer of Batfish, see [dev instructions](README.dev.md) on how to build images and push them to Docker Hub.

--- a/README.md
+++ b/README.md
@@ -1,45 +1,17 @@
 # Batfish Docker Images
 
-This repo contains the files necessary to build [Batfish](https://github.com/batfish/batfish) and `allinone` (Batfish plus [Pybatfish](https://github.com/batfish/pybatfish) and Jupyter) docker images.  
-Using one of the prebuilt containers from [Docker hub](https://hub.docker.com/u/batfish/dashboard/) is the quickest and easiest way to get started using Batfish.
+This repo contains the source files necessary to build [Batfish](https://github.com/batfish/batfish) and 
+`allinone` (Batfish plus [Pybatfish](https://github.com/batfish/pybatfish) and Jupyter) docker images.  
 
-
-## Building and Pushing
-
-The `build_images.sh` script builds a Batfish docker image, tests it with Pybatfish integration tests, builds an `allinone` docker image (with Jupyter, Pybatfish, and Batfish), 
-and finally pushes both of these images to the public Batfish organization on docker hub.  
-Specific Batfish and Pybatfish commit hashes can be passed into the script to build from those commits instead of head (the default).  
-For example, the following command will build images from the Batfish commit `3337ec...` and Pybatfish commit `ddcb50...`:
-```
-sh build_images.sh 3337ecf49f9f754d502e8aa5443919bea18afdd6 ddcb50bb8c05cbcfa71c261c146bc1360e581961
-```
-Any image built will be tagged with the corresponding Batfish and Pybatfish commits.
-
+Using one of the pre-built containers from [Docker hub](https://hub.docker.com/u/batfish/dashboard/) 
+is the quickest and easiest way to get started using Batfish.
 
 ## Running Containers
 
-### Allinone
-To run the Batfish + Pybatfish + Jupyter docker image for the first time, run:
-```
-mkdir -p networks
-docker run -v $(pwd)/networks:/notebooks/custom_networks:ro -v /etc/group:/etc/group:ro -v /etc/passwd:/etc/passwd:ro --user=$(id -u) --env HOME="/notebooks" -p 8888:8888 batfish/allinone:latest
-```
-This does several things to enable data to be passed into the container from the host:
-* Creates `networks` directory on the host owned and accessible by the current user
-* Runs Batfish and Jupyter processes in the container as the current user
-* Mounts the host's `networks` dir as read-only for the container (specifically Jupyter) to view its contents
-* Mounts the host's `group` and `passwd` files so the host user can run Batfish and Jupyter inside the container (so any files created are owned and accessible by them on the host as well as in the container)
-* Forwards the container Jupyter port to the host's port 8888, so notebooks can be accessed from the host machine with `http://localhost:8888/`
+* For a getting started experience, follow the [All-in-one guide](allinone.md).
+* For running the Batfish service *only*, follow the [Service guide](batfish.md).
 
-Can alternatively run the following to gain access to the Batfish data saves on disk (and make that data persistent):
-```
-mkdir -p networks
-mkdir -p data
-docker run -v $(pwd)/networks:/notebooks/custom_networks:ro -v $(pwd)/data:/data -v /etc/group:/etc/group:ro -v /etc/passwd:/etc/passwd:ro --user=$(id -u):$(id -g) --env HOME="/notebooks" -p 8888:8888 batfish/allinone:latest
-```
+## Building and Pushing images
 
-### Batfish
-To run the docker image just containing Batfish, run:
-```
-docker run -p 9997:9997 -p 9996:9996 batfish/batfish:latest
-```
+If you are a developer of batfish see [dev instructions](README.dev.md) on how to build images
+and push them to docker hub.

--- a/allinone.dockerfile
+++ b/allinone.dockerfile
@@ -1,0 +1,29 @@
+ARG TAG=latest
+FROM batfish/batfish:$TAG
+
+# ASSETS is the directory containing the Pybatfish Python wheel
+# and the notebooks/ directory (containing the Jupyter notebooks)
+ARG ASSETS
+# PYBATFISH_VERSION is the version number embedded in the Python wheel in the ASSETS dir
+ARG PYBATFISH_VERSION
+
+COPY ${ASSETS} ./
+
+RUN apt-get update && apt-get install -y \
+    python3 \
+    python3-pip \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+
+# Pybatfish + Jupyter
+EXPOSE 8888
+RUN pip3 install pybatfish-${PYBATFISH_VERSION}-py2.py3-none-any.whl \
+   attrdict \
+   jupyter \
+   matplotlib \
+   networkx \
+&& rm pybatfish-${PYBATFISH_VERSION}-py2.py3-none-any.whl
+
+# Run both Batfish and Jupyter notebook
+ENTRYPOINT ["./wrapper.sh"]

--- a/allinone.dockerfile
+++ b/allinone.dockerfile
@@ -12,18 +12,19 @@ COPY ${ASSETS} ./
 RUN apt-get update && apt-get install -y \
     python3 \
     python3-pip \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 
 # Pybatfish + Jupyter
 EXPOSE 8888
 RUN pip3 install pybatfish-${PYBATFISH_VERSION}-py2.py3-none-any.whl \
-   attrdict \
-   jupyter \
-   matplotlib \
-   networkx \
-&& rm pybatfish-${PYBATFISH_VERSION}-py2.py3-none-any.whl
+    attrdict \
+    jupyter \
+    matplotlib \
+    networkx \
+    && rm pybatfish-${PYBATFISH_VERSION}-py2.py3-none-any.whl \
+    && chmod 777 notebooks
 
 # Run both Batfish and Jupyter notebook
 ENTRYPOINT ["./wrapper.sh"]

--- a/allinone.dockerfile
+++ b/allinone.dockerfile
@@ -24,7 +24,8 @@ RUN pip3 install pybatfish-${PYBATFISH_VERSION}-py2.py3-none-any.whl \
     matplotlib \
     networkx \
     && rm pybatfish-${PYBATFISH_VERSION}-py2.py3-none-any.whl \
-    && chmod 777 notebooks
+    && find notebooks -type d -exec chmod 777 {} \; \
+    && find notebooks -type f -exec chmod 666 {} \;
 
 # Run both Batfish and Jupyter notebook
 ENTRYPOINT ["./wrapper.sh"]

--- a/allinone.md
+++ b/allinone.md
@@ -1,10 +1,10 @@
 # Allinone Batfish docker image
 
-This image contains the [Batfish service][bf], the [Pybatfish client][pybf], and the exaple
-Jupyter notebooks for convenient introduction to batfish capabilities.
+This image contains the [Batfish service][bf], the [Pybatfish client][pybf], and the example
+Jupyter notebooks for convenient introduction to Batfish capabilities.
 
 ## Available tags
-Currently the `latest` tag is the most preferred way to get a working version
+Currently the `latest` tag is the most preferred way to get a working version.
 
 ## Running the image, no persistent storage
 
@@ -28,11 +28,11 @@ This does several things to enable data to be passed into the container from the
   (so any files created are owned and accessible by them on the host as well as in the container)
 * Forwards the container Jupyter port to the host's port 8888, so notebooks can be accessed from the host machine with `http://localhost:8888/`
 
-## Running the image with persisitent storage
+## Running the image with persistent storage
 
 1. `docker pull batfish/allinone` -- This pulls the image
 2. `mkdir -p networks` -- Sets up a folder for you to put network configurations (can be empty for now)
-3. `mddir -p data` -- Sets up a folder for persistent storage
+3. `mkdir -p data` -- Sets up a folder for persistent storage
 4. Run the docker container:
 ```
 docker run \
@@ -42,8 +42,8 @@ docker run \
   --env HOME="/notebooks" -p 8888:8888 batfish/allinone:latest
 ```
 
-This allows batfish to store data on your disk so that if you stop/delete and restart the container, 
-internal batfish data remains.
+This allows Batfish to store data on your disk so that if you stop/delete and restart the container, 
+internal Batfish data remains.
 
 [bf]: https://github.com/batfish/batfish
 [pybf]: https://github.com/batfish/pybatfish

--- a/allinone.md
+++ b/allinone.md
@@ -1,0 +1,49 @@
+# Allinone Batfish docker image
+
+This image contains the [Batfish service][bf], the [Pybatfish client][pybf], and the exaple
+Jupyter notebooks for convenient introduction to batfish capabilities.
+
+## Available tags
+Currently the `latest` tag is the most preferred way to get a working version
+
+## Running the image, no persistent storage
+
+To run the `allinone` docker image for the first time, run:
+
+1. `docker pull batfish/allinone` -- This pulls the image
+2. `mkdir -p networks` -- Sets up a folder for you to put network configurations (can be empty for now)
+3. Run the docker container:
+```
+docker run \
+  -v $(pwd)/networks:/notebooks/custom_networks:ro \
+  -v /etc/group:/etc/group:ro \
+  -v /etc/passwd:/etc/passwd:ro --user=$(id -u):$(id -g) \
+  --env HOME="/notebooks" -p 8888:8888 batfish/allinone:latest
+```
+This does several things to enable data to be passed into the container from the host:
+* Makes the `networks` directory on the host owned and accessible by the current user
+* Runs Batfish and Jupyter processes in the container as the current user
+* Mounts the host's `networks` dir as read-only for the container (specifically Jupyter) to view its contents
+* Mounts the host's `group` and `passwd` files so the host user can run Batfish and Jupyter inside the container 
+  (so any files created are owned and accessible by them on the host as well as in the container)
+* Forwards the container Jupyter port to the host's port 8888, so notebooks can be accessed from the host machine with `http://localhost:8888/`
+
+## Running the image with persisitent storage
+
+1. `docker pull batfish/allinone` -- This pulls the image
+2. `mkdir -p networks` -- Sets up a folder for you to put network configurations (can be empty for now)
+3. `mddir -p data` -- Sets up a folder for persistent storage
+4. Run the docker container:
+```
+docker run \
+  -v $(pwd)/networks:/notebooks/custom_networks:ro \
+  -v $(pwd)/data:/data -v /etc/group:/etc/group:ro \
+  -v /etc/passwd:/etc/passwd:ro --user=$(id -u):$(id -g) \
+  --env HOME="/notebooks" -p 8888:8888 batfish/allinone:latest
+```
+
+This allows batfish to store data on your disk so that if you stop/delete and restart the container, 
+internal batfish data remains.
+
+[bf]: https://github.com/batfish/batfish
+[pybf]: https://github.com/batfish/pybatfish

--- a/batfish.dockerfile
+++ b/batfish.dockerfile
@@ -1,0 +1,41 @@
+FROM ubuntu:16.04
+
+# ASSETS is the directory containing allinone-bundle.jar (the Batfish jar)
+# and questions/ directory (containing question templates to be loaded by Batfish)
+ARG ASSETS
+
+# Make /data dir available to any user, so this container can be run by any user
+RUN mkdir -p /data
+RUN chmod a+rw /data
+COPY ${ASSETS} ./
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/
+ENV JAVA_LIBRARY_PATH /usr/lib
+
+# Base package setup
+RUN apt-get update && apt-get install -y \
+    binutils \
+    libgomp1 \
+    lsb-release \
+    openjdk-8-jre-headless \
+    wget \
+    zip \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* \
+    /var/cache/oracle*
+
+# Z3
+ADD https://raw.githubusercontent.com/batfish/batfish/master/tools/install_z3.sh .
+RUN bash install_z3.sh \
+&& rm -r ~/.batfish_z3_cache/
+
+# Batfish
+EXPOSE 9996-9997
+CMD ["java", \
+   "-XX:+UnlockExperimentalVMOptions", \
+   "-XX:+UseCGroupMemoryLimitForHeap", \
+   "-XX:MaxRAMFraction=1", \
+   "-cp", "allinone-bundle.jar", \
+   "org.batfish.allinone.Main", \
+   "-runclient", "false", \
+   "-loglevel", "warn", \
+   "-coordinatorargs", "-templatedirs questions -containerslocation /data/containers"]

--- a/batfish.dockerfile
+++ b/batfish.dockerfile
@@ -19,23 +19,22 @@ RUN apt-get update && apt-get install -y \
     openjdk-8-jre-headless \
     wget \
     zip \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/* \
-    /var/cache/oracle*
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /var/cache/oracle*
 
 # Z3
 ADD https://raw.githubusercontent.com/batfish/batfish/master/tools/install_z3.sh .
 RUN bash install_z3.sh \
-&& rm -r ~/.batfish_z3_cache/
+    && rm -r ~/.batfish_z3_cache/
 
 # Batfish
 EXPOSE 9996-9997
 CMD ["java", \
-   "-XX:+UnlockExperimentalVMOptions", \
-   "-XX:+UseCGroupMemoryLimitForHeap", \
-   "-XX:MaxRAMFraction=1", \
-   "-cp", "allinone-bundle.jar", \
-   "org.batfish.allinone.Main", \
-   "-runclient", "false", \
-   "-loglevel", "warn", \
-   "-coordinatorargs", "-templatedirs questions -containerslocation /data/containers"]
+    "-XX:+UnlockExperimentalVMOptions", \
+    "-XX:+UseCGroupMemoryLimitForHeap", \
+    "-XX:MaxRAMFraction=1", \
+    "-cp", "allinone-bundle.jar", \
+    "org.batfish.allinone.Main", \
+    "-runclient", "false", \
+    "-loglevel", "warn", \
+    "-coordinatorargs", "-templatedirs questions -containerslocation /data/containers"]

--- a/batfish.md
+++ b/batfish.md
@@ -1,10 +1,10 @@
 # Batfish service docker image
 
-This image contains only the core batfish service. 
+This image contains only the core Batfish service. 
 
 ## Available tags
 
-Currently the `latest` tag is the most preferred way to get a working version
+Currently the `latest` tag is the most preferred way to get a working version.
 
 ## Running the container
 
@@ -17,7 +17,6 @@ You can now use the Pybatfish client to interact with the service.
 
 ### Running with persistent storage
 
-If you'd like to save batfish state across different invocations of the container, 
-simply mount a folder (or volume) over `/data`, like so:
+If you'd like to save Batfish state across different invocations of the container, simply mount a folder (or volume) over `/data`, like so:
 
 `mkdir data && docker run -v $(pwd)/data:/data -p 9997:9997 -p 9996:9996 batfish/batfish`

--- a/batfish.md
+++ b/batfish.md
@@ -20,4 +20,4 @@ You can now use the Pybatfish client to interact with the service.
 If you'd like to save batfish state across different invocations of the container, 
 simply mount a folder (or volume) over `/data`, like so:
 
-`docker run -v $(pwd)/data:/data -p 9997:9997 -p 9996:9996 batfish/batfish`
+`mkdir data && docker run -v $(pwd)/data:/data -p 9997:9997 -p 9996:9996 batfish/batfish`

--- a/batfish.md
+++ b/batfish.md
@@ -1,0 +1,23 @@
+# Batfish service docker image
+
+This image contains only the core batfish service. 
+
+## Available tags
+
+Currently the `latest` tag is the most preferred way to get a working version
+
+## Running the container
+
+To run the Batfish service run the following:
+
+ 1. `docker pull batfish/batfish`
+ 2. `docker run -p 9997:9997 -p 9996:9996 batfish/batfish`
+
+You can now use the Pybatfish client to interact with the service.
+
+### Running with persistent storage
+
+If you'd like to save batfish state across different invocations of the container, 
+simply mount a folder (or volume) over `/data`, like so:
+
+`docker run -v $(pwd)/data:/data -p 9997:9997 -p 9996:9996 batfish/batfish`

--- a/build_images.sh
+++ b/build_images.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# This script tests and builds Batfish and Batfish+Pybatfish+Jupyter docker images
+# Optionally pass in Batfish and Pybatfish commit hashes to build from specific commits instead of head, for example:
+# sh build_images.sh 3337ecf49f9f754d502e8aa5443919bea18afdd6 ddcb50bb8c05cbcfa71c261c146bc1360e581961
+set -x
+
+# Hack to see if a particular port is free
+function is_port_free() {
+  echo -ne "\035" | telnet 127.0.0.1 $1 > /dev/null 2>&1;
+  [ $? -eq 1 ] && return 0;
+  echo "port $1 in use" && return 1;
+}
+
+# Handle docker container cleanup
+function finish {
+    # Cleanup docker container if it was started and is still running
+    if [ -n ${BATFISH_CONTAINER} ]
+    then
+      if docker top ${BATFISH_CONTAINER} &>/dev/null
+        then
+          docker stop ${BATFISH_CONTAINER}
+          echo stopped Batfish container
+        fi
+    fi
+}
+
+
+trap finish EXIT
+
+# Make sure the ports Batfish will use are free
+is_port_free 9996 || exit $?
+is_port_free 9997 || exit $?
+# Exit on error after checking ports, since port-check-hack relies on errors
+set -e
+
+# Asset directory setup
+WORK_DIR="$PWD"
+TEMP_DIR=temp
+ASSETS_REL_PATH=${TEMP_DIR}/assets
+ASSETS_FULL_PATH=${WORK_DIR}/${ASSETS_REL_PATH}
+PY_ASSETS_REL_PATH=${TEMP_DIR}/py_assets
+PY_ASSETS_FULL_PATH=${WORK_DIR}/${PY_ASSETS_REL_PATH}
+mkdir -p ${ASSETS_FULL_PATH}
+mkdir -p ${PY_ASSETS_FULL_PATH}
+
+
+# Batfish
+pushd ${TEMP_DIR}
+git clone https://github.com/batfish/batfish.git
+## Build and save commit info
+pushd batfish
+if [ "$1" != "" ]; then
+    echo "Using specific Batfish commit $1"
+    git reset --hard $1
+fi
+mvn clean -f projects/pom.xml install
+BATFISH_TAG=$(git rev-parse --short HEAD)
+BATFISH_VERSION=$(grep -1 batfish-parent "projects/pom.xml" | grep version | sed 's/[<>]/|/g' | cut -f3 -d\|)
+echo BATFISH_TAG is $BATFISH_TAG
+echo BATFISH_VERSION is $BATFISH_VERSION
+popd
+cp batfish/projects/allinone/target/allinone-bundle-${BATFISH_VERSION}.jar ${ASSETS_FULL_PATH}/allinone-bundle.jar
+cp -r batfish/questions ${ASSETS_FULL_PATH}
+popd
+docker build -f batfish.dockerfile -t batfish/batfish:sha_${BATFISH_TAG} --build-arg ASSETS=${ASSETS_REL_PATH} .
+
+
+# Pybatfish
+pushd ${TEMP_DIR}
+git clone https://github.com/batfish/pybatfish.git
+## Build and save commit info
+pushd pybatfish
+if [ "$2" != "" ]; then
+    echo "Using specific Pybatfish commit $2"
+    git reset --hard $2
+fi
+virtualenv .env
+source .env/bin/activate
+pip install jupyter jupyter_client nbconvert pytest wheel
+python setup.py sdist bdist_wheel
+PYBATFISH_TAG=$(git rev-parse --short HEAD)
+PYBATFISH_VERSION=$(python3 setup.py --version)
+echo PYBATFISH_TAG is $PYBATFISH_TAG
+echo PYBATFISH_VERSION is $PYBATFISH_VERSION
+pip install .
+ln -s ../batfish/questions
+# Start up batfish container
+BATFISH_CONTAINER=$(docker run -d -p 9996:9996 -p 9997:9997 batfish/batfish:sha_${BATFISH_TAG})
+# Poll until we can connect to the container
+while ! curl http://localhost:9996/
+do
+  echo "$(date) - waiting for Batfish to start"
+  sleep 1
+done
+echo "$(date) - connected to Batfish"
+# Run pybatfish integration tests on batfish container
+py.test tests/integration
+deactivate
+docker stop ${BATFISH_CONTAINER}
+popd
+cp pybatfish/dist/pybatfish-${PYBATFISH_VERSION}-py2.py3-none-any.whl ${PY_ASSETS_FULL_PATH}
+cp -r pybatfish/jupyter_notebooks/ ${PY_ASSETS_FULL_PATH}/notebooks
+popd
+
+
+# Add latest tag to the batfish image since we know it works with pybatfish
+docker tag batfish/batfish:sha_${BATFISH_TAG} batfish/batfish:latest
+
+# Combined container stuff
+cp wrapper.sh ${PY_ASSETS_FULL_PATH}
+docker build -f allinone.dockerfile -t batfish/allinone:sha_${BATFISH_TAG}_${PYBATFISH_TAG} -t batfish/allinone:latest --build-arg PYBATFISH_VERSION=${PYBATFISH_VERSION} --build-arg ASSETS=${PY_ASSETS_REL_PATH} --build-arg TAG=sha_${BATFISH_TAG} .
+
+
+# Cleanup the temp directory if successful
+rm -rf ${TEMP_DIR}
+
+# Push the docker images after successfully build
+docker push batfish/batfish:sha_${BATFISH_TAG}
+docker push batfish/batfish:latest
+docker push batfish/allinone:sha_${BATFISH_TAG}_${PYBATFISH_TAG}
+docker push batfish/allinone:latest

--- a/build_images.sh
+++ b/build_images.sh
@@ -1,14 +1,28 @@
 #!/usr/bin/env bash
+
 # This script tests and builds Batfish and Batfish+Pybatfish+Jupyter docker images
 # Optionally pass in Batfish and Pybatfish commit hashes to build from specific commits instead of head, for example:
 # sh build_images.sh 3337ecf49f9f754d502e8aa5443919bea18afdd6 ddcb50bb8c05cbcfa71c261c146bc1360e581961
-set -x
 
-# Hack to see if a particular port is free
+# Quick check to see if a particular port is free
 function is_port_free() {
   echo -ne "\035" | telnet 127.0.0.1 $1 > /dev/null 2>&1;
   [ $? -eq 1 ] && return 0;
   echo "port $1 in use" && return 1;
+}
+
+# Asset directory setup
+WORK_DIR="$PWD"
+TEMP_DIR=$(mktemp -d)
+ASSETS_REL_PATH=./assets
+ASSETS_FULL_PATH=${WORK_DIR}/${ASSETS_REL_PATH}
+PY_ASSETS_REL_PATH=./py_assets
+PY_ASSETS_FULL_PATH=${WORK_DIR}/${PY_ASSETS_REL_PATH}
+
+function cleanup_dirs {
+    rm -rf ${TEMP_DIR}
+    rm -rf ${ASSETS_FULL_PATH}
+    rm -rf ${PY_ASSETS_FULL_PATH}
 }
 
 # Handle docker container cleanup
@@ -22,29 +36,27 @@ function finish {
           echo stopped Batfish container
         fi
     fi
+    cleanup_dirs
 }
 
-
+# Cleanup on exit
 trap finish EXIT
 
-# Make sure the ports Batfish will use are free
+# Make sure the ports Batfish will use are free, we will need that for testing
 is_port_free 9996 || exit $?
 is_port_free 9997 || exit $?
+
 # Exit on error after checking ports, since port-check-hack relies on errors
 set -e
 
-# Asset directory setup
-WORK_DIR="$PWD"
-TEMP_DIR=temp
-ASSETS_REL_PATH=${TEMP_DIR}/assets
-ASSETS_FULL_PATH=${WORK_DIR}/${ASSETS_REL_PATH}
-PY_ASSETS_REL_PATH=${TEMP_DIR}/py_assets
-PY_ASSETS_FULL_PATH=${WORK_DIR}/${PY_ASSETS_REL_PATH}
 mkdir -p ${ASSETS_FULL_PATH}
 mkdir -p ${PY_ASSETS_FULL_PATH}
 
 
 # Batfish
+echo "Cloning and building batfish"
+echo "Using tmp dir: ${TEMP_DIR}"
+
 pushd ${TEMP_DIR}
 git clone https://github.com/batfish/batfish.git
 ## Build and save commit info
@@ -53,18 +65,19 @@ if [ "$1" != "" ]; then
     echo "Using specific Batfish commit $1"
     git reset --hard $1
 fi
-mvn clean -f projects/pom.xml install
+mvn clean -f projects/pom.xml package
 BATFISH_TAG=$(git rev-parse --short HEAD)
 BATFISH_VERSION=$(grep -1 batfish-parent "projects/pom.xml" | grep version | sed 's/[<>]/|/g' | cut -f3 -d\|)
-echo BATFISH_TAG is $BATFISH_TAG
-echo BATFISH_VERSION is $BATFISH_VERSION
+echo "BATFISH_TAG is $BATFISH_TAG"
+echo "BATFISH_VERSION is $BATFISH_VERSION"
 popd
 cp batfish/projects/allinone/target/allinone-bundle-${BATFISH_VERSION}.jar ${ASSETS_FULL_PATH}/allinone-bundle.jar
 cp -r batfish/questions ${ASSETS_FULL_PATH}
 popd
-docker build -f batfish.dockerfile -t batfish/batfish:sha_${BATFISH_TAG} --build-arg ASSETS=${ASSETS_REL_PATH} .
+docker build -f ${WORK_DIR}/batfish.dockerfile -t batfish/batfish:sha_${BATFISH_TAG} --build-arg ASSETS=${ASSETS_REL_PATH} .
 
 
+echo "Cloning and building pybatfish"
 # Pybatfish
 pushd ${TEMP_DIR}
 git clone https://github.com/batfish/pybatfish.git
@@ -74,6 +87,8 @@ if [ "$2" != "" ]; then
     echo "Using specific Pybatfish commit $2"
     git reset --hard $2
 fi
+
+# Create virtual env + dependencies so we can build the wheel
 virtualenv .env
 source .env/bin/activate
 pip install jupyter jupyter_client nbconvert pytest wheel
@@ -84,6 +99,7 @@ echo PYBATFISH_TAG is $PYBATFISH_TAG
 echo PYBATFISH_VERSION is $PYBATFISH_VERSION
 pip install .
 ln -s ../batfish/questions
+
 # Start up batfish container
 BATFISH_CONTAINER=$(docker run -d -p 9996:9996 -p 9997:9997 batfish/batfish:sha_${BATFISH_TAG})
 # Poll until we can connect to the container
@@ -93,6 +109,7 @@ do
   sleep 1
 done
 echo "$(date) - connected to Batfish"
+
 # Run pybatfish integration tests on batfish container
 py.test tests/integration
 deactivate
@@ -102,17 +119,19 @@ cp pybatfish/dist/pybatfish-${PYBATFISH_VERSION}-py2.py3-none-any.whl ${PY_ASSET
 cp -r pybatfish/jupyter_notebooks/ ${PY_ASSETS_FULL_PATH}/notebooks
 popd
 
-
 # Add latest tag to the batfish image since we know it works with pybatfish
 docker tag batfish/batfish:sha_${BATFISH_TAG} batfish/batfish:latest
 
 # Combined container stuff
 cp wrapper.sh ${PY_ASSETS_FULL_PATH}
-docker build -f allinone.dockerfile -t batfish/allinone:sha_${BATFISH_TAG}_${PYBATFISH_TAG} -t batfish/allinone:latest --build-arg PYBATFISH_VERSION=${PYBATFISH_VERSION} --build-arg ASSETS=${PY_ASSETS_REL_PATH} --build-arg TAG=sha_${BATFISH_TAG} .
+docker build -f ${WORK_DIR}/allinone.dockerfile -t batfish/allinone:sha_${BATFISH_TAG}_${PYBATFISH_TAG} -t batfish/allinone:latest \
+  --build-arg PYBATFISH_VERSION=${PYBATFISH_VERSION} \
+  --build-arg ASSETS=${PY_ASSETS_REL_PATH} \
+  --build-arg TAG=sha_${BATFISH_TAG} .
 
 
 # Cleanup the temp directory if successful
-rm -rf ${TEMP_DIR}
+cleanup_dirs
 
 # Push the docker images after successfully build
 docker push batfish/batfish:sha_${BATFISH_TAG}

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Copied from docker docs https://docs.docker.com/config/containers/multi-service_container/
+
+# Start Batfish
+java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:MaxRAMFraction=1 -cp allinone-bundle.jar org.batfish.allinone.Main -runclient false -loglevel warn -coordinatorargs "-templatedirs questions -containerslocation /data/containers"&
+status=$?
+if [ $status -ne 0 ]; then
+  echo "Failed to start batfish: $status"
+  exit $status
+fi
+
+# Start Jupyter notebook
+cd notebooks
+jupyter notebook --allow-root --ip=0.0.0.0 --port=8888&
+status=$?
+if [ $status -ne 0 ]; then
+  echo "Failed to start Jupyter notebook: $status"
+  exit $status
+fi
+
+# Check that Batfish and Jupyter are still running every minute
+while sleep 60; do
+  ps aux |grep java |grep -q -v grep
+  PROCESS_1_STATUS=$?
+  ps aux |grep jupyter |grep -q -v grep
+  PROCESS_2_STATUS=$?
+  # If either stops, go ahead and shutdown
+  if [ $PROCESS_1_STATUS -ne 0 ]; then
+    echo "Java has exited."
+    exit 1
+  fi
+  if [ $PROCESS_2_STATUS -ne 0 ]; then
+    echo "Jupyter has exited."
+    exit 1
+  fi
+done

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -2,7 +2,11 @@
 # Copied from docker docs https://docs.docker.com/config/containers/multi-service_container/
 
 # Start Batfish
-java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:MaxRAMFraction=1 -cp allinone-bundle.jar org.batfish.allinone.Main -runclient false -loglevel warn -coordinatorargs "-templatedirs questions -containerslocation /data/containers"&
+java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:MaxRAMFraction=1 \
+  -cp allinone-bundle.jar org.batfish.allinone.Main \
+  -runclient false \
+  -loglevel warn \
+  -coordinatorargs "-templatedirs questions -containerslocation /data/containers"&
 status=$?
 if [ $status -ne 0 ]; then
   echo "Failed to start batfish: $status"
@@ -11,7 +15,7 @@ fi
 
 # Start Jupyter notebook
 cd notebooks
-jupyter notebook --allow-root --ip=0.0.0.0 --port=8888&
+jupyter notebook --allow-root --ip=0.0.0.0 --port=8888 &
 status=$?
 if [ $status -ne 0 ]; then
   echo "Failed to start Jupyter notebook: $status"


### PR DESCRIPTION
Add dockerfiles + script to generate and push docker images for:

1) Batfish
2) "allinone" (Batfish + Pybatfish + Jupyter) - Batfish and Jupyter are both run in parallel via a wrapper script inside the docker container

The build script can build these images for specific commits or from master/head (default), runs integration tests between Pybatfish and the built Batfish container, and pushes the docker images to docker hub if the builds and tests are successful.
