### PR TITLE
Add build-only option for build script

### DIFF
--- a/README.dev.md
+++ b/README.dev.md
@@ -1,16 +1,22 @@
 # Building and pushing images
 
 A single `build_images.sh` script is provided that:
-- Builds a Batfish docker image,
-- Tests it with Pybatfish integration tests,
-- Builds an `allinone` docker image (with Jupyter, Pybatfish, and Batfish), 
-- And finally pushes both of these images to the public Batfish organization on Docker Hub.  
+- Builds a Batfish docker image
+- Tests it with Pybatfish integration tests
+- Builds an `allinone` docker image (with Jupyter, Pybatfish, and Batfish)
+- And optionally pushes both of these images to the public Batfish organization on Docker Hub
 
-Specific Batfish and Pybatfish commit hashes can be passed into the script 
-to build from those commits instead of `HEAD` at `master` (the default). For example, the following command will build images from the Batfish commit `3337ec...` and Pybatfish commit `ddcb50...`:
+The script takes in three optional, ordered parameters:
+- build|push (default is to build the images, not push them)
+- specific Batfish commit (default is to use `HEAD` at `master`)
+- specific Pybatfish commit (default is to use `HEAD` at `master`)
+
+For example, the following command will build and push images from the Batfish commit `3337ec...` and Pybatfish commit `ddcb50...`:
 ```
-sh build_images.sh 3337ecf49f9f754d502e8aa5443919bea18afdd6 ddcb50bb8c05cbcfa71c261c146bc1360e581961
+sh build_images.sh push 3337ecf49f9f754d502e8aa5443919bea18afdd6 ddcb50bb8c05cbcfa71c261c146bc1360e581961
+```
+To build from head, simply run:
+```
+sh build_images.sh
 ```
 Any image built will be tagged with the corresponding Batfish and Pybatfish commits and the `latest` tag.
-
-**NOTE: If you have the correct permissions to Docker Hub, the images will be pushed to Docker Hub.**


### PR DESCRIPTION
Add param for building versus pushing, update dev readme.

Now, you can run the following to test and build the images:
`build_images.sh` or `build_images.sh build`
And to test, build, and push:
`build_images.sh push`

Fixes #3 
