### PR TITLE
Use openjdk8 instead of oracle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: xenial
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 sudo: true
 


### PR DESCRIPTION
Use openjdk8 instead of oraclejdk8 - since Xenial travis builds no longer support it, like https://github.com/batfish/batfish/commit/1d23062524204c8a2fa0f5721136edd51e54df0b