### PR TITLE
Use same pom.xml for all commands so versions are synced

### DIFF
--- a/build-infra/Dockerfile
+++ b/build-infra/Dockerfile
@@ -79,7 +79,7 @@ ENV PATH $PATH:/home/${USERNAME}/workdir/apache-maven-${MAVEN_VERSION}/bin:/home
 RUN git clone --depth=1 --branch=master https://github.com/batfish/batfish \
 && cd batfish \
 && mvn -f projects verify -DskipTests=false \
-&& mvn dependency:get -Dartifact=com.google.googlejavaformat:google-java-format:${GOOGLE_JAVA_FORMAT_VERSION}:jar:all-deps \
-&& mvn dependency:get -Dartifact=org.jacoco:org.jacoco.cli:${JACOCO_VERSION}:jar:nodeps \
+&& mvn -f projects dependency:get -Dartifact=com.google.googlejavaformat:google-java-format:${GOOGLE_JAVA_FORMAT_VERSION}:jar:all-deps \
+&& mvn -f projects dependency:get -Dartifact=org.jacoco:org.jacoco.cli:${JACOCO_VERSION}:jar:nodeps \
 && cd .. \
 && rm -rf batfish


### PR DESCRIPTION
This inherits the dependency management from Batfish so we download consistent versions of Guava, ASM, Jackson, etc. that happen to be shared by Batfish and these libs.