### PR TITLE
Pin tornado to fix notebooks

### DIFF
--- a/allinone.dockerfile
+++ b/allinone.dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && apt-get install -y \
 EXPOSE 8888
 RUN pip3 install pybatfish-${PYBATFISH_VERSION}-py2.py3-none-any.whl \
     attrdict \
+    "tornado<6.0" \
     jupyter \
     matplotlib \
     networkx \


### PR DESCRIPTION
Tornado >=6 breaks the notebooks (see https://github.com/jupyter/notebook/issues/4439)
Pinning to <6 for now, as a quick fix to ship new containers.
