### PR TITLE
Unpin tornado

### DIFF
--- a/allinone.dockerfile
+++ b/allinone.dockerfile
@@ -21,7 +21,6 @@ RUN apt-get update && apt-get install -y \
 EXPOSE 8888
 RUN pip3 install pybatfish-${PYBATFISH_VERSION}-py2.py3-none-any.whl \
     attrdict \
-    tornado \
     jupyter \
     matplotlib \
     networkx \

--- a/allinone.dockerfile
+++ b/allinone.dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install -y \
 EXPOSE 8888
 RUN pip3 install pybatfish-${PYBATFISH_VERSION}-py2.py3-none-any.whl \
     attrdict \
-    "tornado<6.0" \
+    tornado \
     jupyter \
     matplotlib \
     networkx \


### PR DESCRIPTION
`tornado` 6 / `jupyter/notebook` incompatibility fixed in `jupyter/notebook` `5.7.5` (https://github.com/jupyter/notebook/pull/4449).
