### PR TITLE
Update build script to work on Mac

### DIFF
--- a/build_images.sh
+++ b/build_images.sh
@@ -128,7 +128,7 @@ echo "$(date) - connected to Batfish"
 # Run pybatfish integration tests on batfish container
 # Cache doesn't work when folder is mounted in container, so wipe it
 py.test -p no:cacheprovider tests/integration
-# Remove Python cache files, which interfere with running tests inside the container
+# Remove .pyc files generated outside the container, which interfere with running tests inside the container
 find . -name \*.pyc -delete
 deactivate
 docker stop ${BATFISH_CONTAINER}

--- a/build_images.sh
+++ b/build_images.sh
@@ -128,7 +128,8 @@ echo "$(date) - connected to Batfish"
 # Run pybatfish integration tests on batfish container
 # Cache doesn't work when folder is mounted in container, so wipe it
 py.test -p no:cacheprovider tests/integration
-py3clean .
+# Remove Python cache files, which interfere with running tests inside the container
+find . -name \*.pyc -delete
 deactivate
 docker stop ${BATFISH_CONTAINER}
 popd


### PR DESCRIPTION
Use `find` command instead of `py3clean` to remove `.pyc` files.
