### PR TITLE
Update test setup

### DIFF
--- a/build_images.sh
+++ b/build_images.sh
@@ -157,6 +157,7 @@ fi
 # Run tests inside Docker container
 docker run -v $(pwd)/tests/test.sh:/test.sh:ro \
   -v $PYBATFISH_DIR:/pybatfish \
+  -e PYBATFISH_VERSION="${PYBATFISH_VERSION}" \
   --entrypoint /bin/bash \
   batfish/allinone:sha_${BATFISH_TAG}_${PYBATFISH_TAG} test.sh
 

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -13,7 +13,7 @@ apt-get install -y curl
 
 pushd pybatfish
 # Install test dependencies
-pip3 install .[dev]
+pip3 install dist/pybatfish-${PYBATFISH_VERSION}-py2.py3-none-any.whl[dev]
 
 echo Waiting for batfish to start
 # Poll until we can connect to the coordinator


### PR DESCRIPTION
Install `dev` requirements from wheel instead of from source during testing setup.
This gives us the opportunity to reduce the amount of stuff we pass into the container for testing.
