### PR TITLE
Upgrade pip

### DIFF
--- a/allinone.dockerfile
+++ b/allinone.dockerfile
@@ -16,7 +16,10 @@ RUN apt-get update && apt-get install -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN python3 -m pip install --upgrade pip
+RUN pip3 install --upgrade pip
+# Fix system-pip3 clash after update
+# See https://github.com/pypa/pip/issues/5221
+RUN hash -d pip3
 
 # Pybatfish + Jupyter
 EXPOSE 8888

--- a/allinone.dockerfile
+++ b/allinone.dockerfile
@@ -15,8 +15,7 @@ RUN apt-get update && apt-get install -y \
     python3-pip \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
-
-RUN pip3 install --upgrade pip
+    && pip3 install --upgrade pip
 
 # Pybatfish + Jupyter
 EXPOSE 8888

--- a/allinone.dockerfile
+++ b/allinone.dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+RUN python3 -m pip install --upgrade pip
 
 # Pybatfish + Jupyter
 EXPOSE 8888

--- a/allinone.dockerfile
+++ b/allinone.dockerfile
@@ -17,9 +17,6 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install --upgrade pip
-# Fix system-pip3 clash after update
-# See https://github.com/pypa/pip/issues/5221
-RUN hash -d pip3
 
 # Pybatfish + Jupyter
 EXPOSE 8888

--- a/allinone.dockerfile
+++ b/allinone.dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y \
     python3 \
     python3-pip \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
     && pip3 install --upgrade pip
 
 # Pybatfish + Jupyter


### PR DESCRIPTION
Upgrade `pip` in `allinone` image.

Ubuntu installs `pip` `8.1.1` by default (which is lacking a few helpful features like [python_requires specification](https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires)).