### PR TITLE
Use Python 3.7.3 to get around Anaconda bug

### DIFF
--- a/tests/test_batfish_container.sh
+++ b/tests/test_batfish_container.sh
@@ -8,7 +8,7 @@ MAX_BATFISH_STARTUP_WAIT=20
 curl -o conda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
 bash conda.sh -b -p $HOME/miniconda
 export PATH="$HOME/miniconda/bin:$PATH"
-conda create -y -n conda_env python=3.7
+conda create -y -n conda_env python=3.7.3
 source activate conda_env
 
 pip install /assets/pybatfish-${PYBF_VERSION}-py2.py3-none-any.whl[dev]


### PR DESCRIPTION
Get around Anaconda bug https://github.com/ContinuumIO/anaconda-issues/issues/11195 with Python 3.7.4
