### PR TITLE
Unpin miniconda version

### DIFF
--- a/tests/test_batfish_container.sh
+++ b/tests/test_batfish_container.sh
@@ -5,8 +5,7 @@ PYBF_VERSION=$(cat /assets/pybatfish-version.txt)
 MAX_BATFISH_STARTUP_WAIT=20
 
 # Setup conda so we can avoid permission issues setting up Python as non-root user
-# Use version 4.7.10 for now to get around intermittent unpack issue https://github.com/conda/conda/issues/9345
-curl -o conda.sh https://repo.anaconda.com/miniconda/Miniconda3-4.7.10-Linux-x86_64.sh
+curl -o conda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
 bash conda.sh -b -p $HOME/miniconda
 export PATH="$HOME/miniconda/bin:$PATH"
 conda create -y -n conda_env python=3.7


### PR DESCRIPTION
Revert "Pin miniconda version (#44)" since intermittent unpack issue is now resolved.

This reverts commit cd43127a9d12ec0af6744b557f499bd0f8f36c82.
