### PR TITLE
Pin pip for tests

### DIFF
--- a/tests/test_batfish_container.sh
+++ b/tests/test_batfish_container.sh
@@ -11,7 +11,7 @@ conda create -y -n conda_env python=3.7
 source activate conda_env
 
 # pip 20.3 has problems resolving dependencies correctly
-pip install 'pip<20.3'
+pip install 'pip!=20.3'
 
 # Install specific version of Pybatfish if specified, otherwise use the available version/wheel artifacts
 if [ "${PYBATFISH_VERSION-}" == "" ]; then

--- a/tests/test_batfish_container.sh
+++ b/tests/test_batfish_container.sh
@@ -7,11 +7,9 @@ MAX_BATFISH_STARTUP_WAIT=20
 curl -o conda.sh https://repo.anaconda.com/miniconda/Miniconda3-4.7.12.1-Linux-x86_64.sh
 bash conda.sh -b -p $HOME/miniconda
 export PATH="$HOME/miniconda/bin:$PATH"
-conda create -y -n conda_env python=3.7
+# pip 20.3 has problems resolving dependencies correctly, so pin to last working version
+conda create -y -n conda_env python=3.7 pip=20.2.4
 source activate conda_env
-
-# pip 20.3 has problems resolving dependencies correctly
-pip install 'pip!=20.3'
 
 # Install specific version of Pybatfish if specified, otherwise use the available version/wheel artifacts
 if [ "${PYBATFISH_VERSION-}" == "" ]; then

--- a/tests/test_batfish_container.sh
+++ b/tests/test_batfish_container.sh
@@ -8,7 +8,7 @@ curl -o conda.sh https://repo.anaconda.com/miniconda/Miniconda3-4.7.12.1-Linux-x
 bash conda.sh -b -p $HOME/miniconda
 export PATH="$HOME/miniconda/bin:$PATH"
 # pip 20.3 has problems resolving dependencies correctly, so pin to last working version
-# See related ressolver issue: https://github.com/pypa/pip/issues/9187
+# See related resolver issue: https://github.com/pypa/pip/issues/9187
 conda create -y -n conda_env python=3.7 pip=20.2.4
 source activate conda_env
 

--- a/tests/test_batfish_container.sh
+++ b/tests/test_batfish_container.sh
@@ -8,6 +8,7 @@ curl -o conda.sh https://repo.anaconda.com/miniconda/Miniconda3-4.7.12.1-Linux-x
 bash conda.sh -b -p $HOME/miniconda
 export PATH="$HOME/miniconda/bin:$PATH"
 # pip 20.3 has problems resolving dependencies correctly, so pin to last working version
+# See related ressolver issue: https://github.com/pypa/pip/issues/9187
 conda create -y -n conda_env python=3.7 pip=20.2.4
 source activate conda_env
 

--- a/tests/test_batfish_container.sh
+++ b/tests/test_batfish_container.sh
@@ -10,6 +10,9 @@ export PATH="$HOME/miniconda/bin:$PATH"
 conda create -y -n conda_env python=3.7
 source activate conda_env
 
+# pip 20.3 has problems resolving dependencies correctly
+pip install 'pip<20.3'
+
 # Install specific version of Pybatfish if specified, otherwise use the available version/wheel artifacts
 if [ "${PYBATFISH_VERSION-}" == "" ]; then
     PYBF_VERSION=$(cat /assets/pybatfish-version.txt)


### PR DESCRIPTION
Looks like pip 20.3 has issues with dependency resolution, so pin to the last working version.
