### PR TITLE
batfish: package log4j2.yaml correctly

### DIFF
--- a/.buildkite/docker_build_batfish.sh
+++ b/.buildkite/docker_build_batfish.sh
@@ -23,6 +23,7 @@ BF_TAG=$(cat ${ARTIFACT_DIR}/batfish-tag.txt)
 # Setup assets for the Batfish image
 tar xzf ${ARTIFACT_DIR}/questions.tgz -C ${ASSET_DIR}
 cp ${ARTIFACT_DIR}/allinone-bundle.jar ${ASSET_DIR}
+cp ${ABS_SOURCE_DIR}/log4j2.yaml ${ASSET_DIR}
 
 docker build -f ${ABS_SOURCE_DIR}/batfish.dockerfile \
   -t batfish/batfish:${TESTING_TAG}-${BUILDKITE_BUILD_NUMBER} \


### PR DESCRIPTION
Redo batfish/docker#84

commit-id:894c26fb

**Issue references**: 

 - batfish/docker#84