### PR TITLE
CI: More triggers for Cross-Version Test workflow

### DIFF
--- a/.github/workflows/cross_version_test.yml
+++ b/.github/workflows/cross_version_test.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - precommit-triggers
+      - test-triggers
   schedule:
     - cron: '0 0,15,19 * * *'  # 8AM, 12PM, 5PM Pacific; daily
   workflow_dispatch:

--- a/.github/workflows/cross_version_test.yml
+++ b/.github/workflows/cross_version_test.yml
@@ -4,9 +4,35 @@ on:
   push:
     branches:
       - master
+      - precommit-triggers
+  schedule:
+    - cron: '0 0,15,19 * * *'  # 8AM, 12PM, 5PM Pacific; daily
+  workflow_dispatch:
+    inputs:
+      batfish_repo:
+        description: "GitHub repo containing Batfish"
+        type: string
+        required: false
+        default: 'batfish/batfish'
+      batfish_ref:
+        description: "Batfish ref to build a container from"
+        type: string
+        required: false
+        default: 'master'
+      pybatfish_repo:
+        description: "GitHub repo containing Pybatfish"
+        type: string
+        required: false
+        default: 'batfish/pybatfish'
+      pybatfish_ref:
+        description: "Pybatfish ref to build a wheel from"
+        type: string
+        required: false
+        default: 'master'
 
 jobs:
   precommit:
+    if: github.event_name != 'workflow_dispatch'
     uses: ./.github/workflows/reusable-precommit.yml
     with:
       BATFISH_GITHUB_BATFISH_REPO: 'batfish/batfish'
@@ -14,6 +40,26 @@ jobs:
       BATFISH_GITHUB_PYBATFISH_REPO: 'batfish/pybatfish'
       BATFISH_GITHUB_PYBATFISH_REF: 'master'
   test:
+    if: github.event_name != 'workflow_dispatch'
+    needs: precommit
+    uses: ./.github/workflows/reusable-integration-tests.yml
+    with:
+      bf_version: ${{ needs.precommit.outputs.bf_version }}
+      bf_test_artifact_age: "90"
+      bf_min_release_test_count: "3"
+      pybf_min_release_test_count: "3"
+      run_cross_version_tests: true
+
+  precommit_manual_trigger:
+    if: github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/reusable-precommit.yml
+    with:
+      BATFISH_GITHUB_BATFISH_REPO: "${{ github.event.inputs.batfish_repo }}"
+      BATFISH_GITHUB_BATFISH_REF: "${{ github.event.inputs.batfish_ref }}"
+      BATFISH_GITHUB_PYBATFISH_REPO: "${{ github.event.inputs.pybatfish_repo }}"
+      BATFISH_GITHUB_PYBATFISH_REF: "${{ github.event.inputs.pybatfish_ref }}"
+  test_manual_trigger:
+    if: github.event_name == 'workflow_dispatch'
     needs: precommit
     uses: ./.github/workflows/reusable-integration-tests.yml
     with:

--- a/.github/workflows/cross_version_test.yml
+++ b/.github/workflows/cross_version_test.yml
@@ -1,10 +1,5 @@
 name: Cross-Version Tests
 on:
-  pull_request:
-  push:
-    branches:
-      - master
-      - test-triggers
   schedule:
     - cron: '0 0,15,19 * * *'  # 8AM, 12PM, 5PM Pacific; daily
   workflow_dispatch:

--- a/.github/workflows/cross_version_test.yml
+++ b/.github/workflows/cross_version_test.yml
@@ -44,7 +44,6 @@ jobs:
     needs: precommit
     uses: ./.github/workflows/reusable-integration-tests.yml
     with:
-      bf_version: ${{ needs.precommit.outputs.bf_version }}
       bf_test_artifact_age: "90"
       bf_min_release_test_count: "3"
       pybf_min_release_test_count: "3"
@@ -60,10 +59,9 @@ jobs:
       BATFISH_GITHUB_PYBATFISH_REF: "${{ github.event.inputs.pybatfish_ref }}"
   test_manual_trigger:
     if: github.event_name == 'workflow_dispatch'
-    needs: precommit
+    needs: precommit_manual_trigger
     uses: ./.github/workflows/reusable-integration-tests.yml
     with:
-      bf_version: ${{ needs.precommit.outputs.bf_version }}
       bf_test_artifact_age: "90"
       bf_min_release_test_count: "3"
       pybf_min_release_test_count: "3"

--- a/.github/workflows/reusable-integration-tests.yml
+++ b/.github/workflows/reusable-integration-tests.yml
@@ -2,10 +2,6 @@ name: Integration Tests (reusable; depends on precommit workflow running before 
 on:
   workflow_call:
     inputs:
-      bf_version:
-        description: "Batfish version string (in the format YYYY.MM.DD.####)"
-        required: true
-        type: string
       bf_test_artifact_age:
         description: "Test all artifacts released in the last N days"
         required: false


### PR DESCRIPTION
* Enable manual and scheduled triggers for cross-version test workflow
  * Allow specifying repos and refs when manually triggering
* Disable push/PR triggers for cross-version test workflow (just rely on manual and scheduled triggers)
* Remove unneeded `bf_version` input for reusable test workflow

