### PR TITLE
batfish: stop exposing 9997

### DIFF
--- a/batfish.dockerfile
+++ b/batfish.dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* /var/cache/oracle*
 
 # Batfish
-EXPOSE 9996-9997
+EXPOSE 9996
 CMD ["java", \
     "-XX:-UseCompressedOops", \
     "-XX:+UseContainerSupport", \


### PR DESCRIPTION
It's deprecated and unused

---

**Stack**:
- #123
- #122 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*