### PR TITLE
Update workflows for github workflow warnings

### DIFF
--- a/.github/workflows/reusable-integration-tests.yml
+++ b/.github/workflows/reusable-integration-tests.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           # --pattern=202 filters container tags to those containing "202", e.g. "2022.08.22.1234"
           DATE_TAGS="$(python get_docker_versions.py --image batfish/batfish --days=${{ inputs.bf_test_artifact_age }} --minimum=${{ inputs.bf_min_release_test_count }} --json-format --pattern=202)"
-          echo "::set-output name=versions::$DATE_TAGS"
+          echo "versions=$DATE_TAGS" >> $GITHUB_OUTPUT
     outputs:
       versions: ${{ steps.set_versions.outputs.versions }}
   get_pybf_versions:
@@ -57,7 +57,7 @@ jobs:
       - id: set_versions
         run: |
           PYBF_TAGS="$(python get_pypi_versions.py --package pybatfish --days=${{ inputs.bf_test_artifact_age }} --minimum=${{ inputs.pybf_min_release_test_count }} --json-format)"
-          echo "::set-output name=versions::$PYBF_TAGS"
+          echo "versions=$PYBF_TAGS" >> $GITHUB_OUTPUT
     outputs:
       versions: ${{ steps.set_versions.outputs.versions }}
   bf_cross_version_tests:

--- a/.github/workflows/reusable-precommit.yml
+++ b/.github/workflows/reusable-precommit.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - name: Get Build ID
         id: get_build_id
-        run: echo "::set-output name=build_id::$(TZ=America/Los_Angeles date +'%Y.%m.%d').${{ github.run_number }}"
+        run: echo "build_id=$(TZ=America/Los_Angeles date +'%Y.%m.%d').${{ github.run_number }}" >> $GITHUB_OUTPUT
       - name: Checkout Batfish repo
         uses: actions/checkout@v4
         with:
@@ -53,8 +53,8 @@ jobs:
         id: get_bf_sha
         run: |
           cd batfish
-          echo "::set-output name=batfish_sha::$(git rev-parse --short HEAD)"
-          echo "::set-output name=batfish_resolved_sha::$(git rev-parse HEAD)"
+          echo "batfish_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "batfish_resolved_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
       - name: Checkout pybatfish repo
         uses: actions/checkout@v4
         with:
@@ -65,8 +65,8 @@ jobs:
         id: get_pybf_sha
         run: |
           cd pybatfish
-          echo "::set-output name=pybatfish_sha::$(git rev-parse --short HEAD)"
-          echo "::set-output name=pybatfish_resolved_sha::$(git rev-parse HEAD)"
+          echo "pybatfish_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "pybatfish_resolved_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
     outputs:
       bf_version: ${{ steps.get_build_id.outputs.build_id }}
       bf_sha: ${{ steps.get_bf_sha.outputs.batfish_sha }}
@@ -80,7 +80,7 @@ jobs:
     steps:
       - name: Get date
         id: date
-        run: echo "::set-output name=ymd::$(TZ=America/Los_Angeles date +'%Y-%m-%d')"
+        run: echo "ymd=$(TZ=America/Los_Angeles date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
       - name: Checkout Docker repo
         uses: actions/checkout@v4
       - name: Checkout Batfish repo

--- a/.github/workflows/reusable-upload.yml
+++ b/.github/workflows/reusable-upload.yml
@@ -90,7 +90,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYBATFISH_TEST_PYPI_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
+          repository-url: https://test.pypi.org/legacy/
       - name: Set up Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
Check out https://github.com/batfish/docker/actions/runs/15349729791 for a pre-look:

1. `set-output` deprecated
2. `repository_url` deprecated