### PR TITLE
Add lab-validation testing to docker release pipeline

### DIFF
--- a/.github/workflows/cross_version_test.yml
+++ b/.github/workflows/cross_version_test.yml
@@ -45,16 +45,51 @@ jobs:
       bf_min_release_test_count: "2"
       pybf_min_release_test_count: "2" # todo: bump to 3 once we have 3 releases with new API support
       run_cross_version_tests: true
-  # Push public artifacts
-  upload:
+  # Push test/dev artifacts
+  upload_dev:
     needs:
       - precommit
       - test
     uses: ./.github/workflows/reusable-upload.yml
     with:
       bf_version: ${{ needs.precommit.outputs.bf_version }}
-      # Consider manual builds or 8AM Pacific scheduled builds as a release candidate
-      queue_prod_release: ${{ github.event_name == 'workflow_dispatch' || github.event.schedule == '0 15 * * *' }}
+      # Only upload dev/test artifacts, not production
+      queue_prod_release: false
+      test_tag: "test-${{ needs.precommit.outputs.bf_version }}"
+      release_tag: "${{ needs.precommit.outputs.bf_version }}"
+      BATFISH_GITHUB_BATFISH_REPO: "${{ needs.precommit.outputs.batfish_repo }}"
+      BATFISH_GITHUB_PYBATFISH_REPO: "${{ needs.precommit.outputs.pybatfish_repo }}"
+      BATFISH_GITHUB_PYBATFISH_REF: "${{ needs.precommit.outputs.pybatfish_resolved_sha }}"
+    secrets:
+      PYBATFISH_TEST_PYPI_TOKEN: ${{ secrets.PYBATFISH_TEST_PYPI_TOKEN }}
+      PYBATFISH_PYPI_TOKEN: ${{ secrets.PYBATFISH_PYPI_TOKEN }}
+      BATFISH_DOCKER_LOGIN_TOKEN: ${{ secrets.BATFISH_DOCKER_LOGIN_TOKEN }}
+      OPEN_SOURCE_BUILDKITEBOT_PUBLIC_REPO_TOKEN: ${{ secrets.OPEN_SOURCE_BUILDKITEBOT_PUBLIC_REPO_TOKEN }}
+
+  # Validate the uploaded test artifacts with lab-validation
+  lab_validation:
+    needs:
+      - precommit
+      - upload_dev
+    uses: batfish/lab-validation/.github/workflows/reusable-lab-validation.yml@main
+    with:
+      batfish_docker: "batfish/batfish:test-${{ needs.precommit.outputs.bf_version }}"
+      pybatfish_version: "${{ needs.precommit.outputs.bf_version }}"
+      pybatfish_pypi_repo: "test"
+
+  # Push production artifacts only if lab validation passes
+  upload_prod:
+    needs:
+      - precommit
+      - test
+      - lab_validation
+    # Only run production uploads if this is a release candidate AND lab validation passed
+    if: github.event_name == 'workflow_dispatch' || github.event.schedule == '0 15 * * *'
+    uses: ./.github/workflows/reusable-upload.yml
+    with:
+      bf_version: ${{ needs.precommit.outputs.bf_version }}
+      # Only upload production artifacts
+      queue_prod_release: true
       test_tag: "test-${{ needs.precommit.outputs.bf_version }}"
       release_tag: "${{ needs.precommit.outputs.bf_version }}"
       BATFISH_GITHUB_BATFISH_REPO: "${{ needs.precommit.outputs.batfish_repo }}"
@@ -71,7 +106,9 @@ jobs:
     needs:
       - precommit
       - test
-      - upload
+      - upload_dev
+      - lab_validation
+      - upload_prod
     if: |
       failure() &&
       github.ref == 'refs/heads/master' &&


### PR DESCRIPTION
## Summary

Integrates lab-validation testing into the docker release pipeline to validate newly built artifacts before they are promoted to production releases.

## Implementation Details

This change splits the upload process into two phases:

1. **Dev Upload Phase (`upload_dev`)**: Uploads test artifacts to:
   - Docker Hub: `batfish/batfish:test-VERSION`
   - Test PyPI: `pybatfish==VERSION` 

2. **Lab Validation Phase (`lab_validation`)**: Runs the lab-validation test suite against the uploaded test artifacts

3. **Production Upload Phase (`upload_prod`)**: Only runs if lab validation passes and uploads production artifacts with release tags

## Key Changes

- **Split upload job**: Separated `upload` into `upload_dev` and `upload_prod` phases
- **Added lab validation**: Calls `batfish/lab-validation/.github/workflows/reusable-lab-validation.yml@main`
- **Conditional prod release**: Production artifacts only uploaded if lab validation succeeds
- **Updated dependencies**: Slack notifications now depend on all workflow phases

## Test Plan

The integration will:
- Test the specific docker container built during the release (`batfish/batfish:test-VERSION`)
- Test the specific PyPI package uploaded to test.pypi.org (`pybatfish==VERSION`)
- Only allow production releases if lab validation passes against these exact artifacts
- Maintain backward compatibility with existing release triggers and processes

This ensures newly built artifacts are validated before being promoted to production, improving release quality while maintaining the existing development workflow.